### PR TITLE
Add CommonJS build task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -2,12 +2,20 @@ const gulp = require('gulp');
 const tsc = require('gulp-typescript');
 const Server = require('karma').Server;
 const tsProject = tsc.createProject('src/tsconfig.json');
+const tsProjectCommonJS = tsc.createProject('src/tsconfig.json', {
+  module: 'commonjs'
+});
 const tsProjectSpec = tsc.createProject('spec/tsconfig.json');
 
 gulp.task('default', ['build']);
 gulp.task('build', () => {
   return tsProject.src()
     .pipe(tsc(tsProject))
+    .pipe(gulp.dest('build'));
+});
+gulp.task('build:commonjs', () => {
+  return tsProjectCommonJS.src()
+    .pipe(tsc(tsProjectCommonJS))
     .pipe(gulp.dest('build'));
 });
 gulp.task('test', ['test-build:spec', 'test-build:src'], () => {


### PR DESCRIPTION
In order for Courtroom to be required into a Node application, we need to compile the TypeScript modules into CommonJS modules. I have experimented with UMD modules but this complicates bundling with Webpack, so I decided to keep this PR simple.

When publishing to NPM, I would recommend building the Courtroom JS using the new CommonJS build task, which can be kicked off with:

```
$ gulp build:commonjs
```

I have left AMD as the default build task for now. Perhaps it can be used when Courtroom is published to a client-side focussed package manager like Bower.